### PR TITLE
update hercule dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 		},
 		hercule: {
 			example: {
-				src: 'node_modules/hercule/examples/api-blueprint/gist-fox.apib',
+				src: 'test/fixtures/api-blueprint/gist-fox.apib',
 				dest: '.grunt/gist-fox.md'
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"dependencies": {
 		"grunt-tabs4life": "^1.0.11",
-		"hercule": "^0.2.3"
+		"hercule": "^1.2.1"
 	},
 	"devDependencies": {
 		"chai": "^3.0.0",

--- a/tasks/hercule.js
+++ b/tasks/hercule.js
@@ -14,6 +14,9 @@ module.exports = function (grunt) {
 		var dest = this.data.dest;
 		
 		hercule.transcludeFile(src,
+			function logger(msg) {
+				grunt.verbose.writeln(msg);
+			},
 			function callback(doc) {
 				// FIXME: unsure how to detect transclusion error since only output
 				// string is passed in.

--- a/tasks/hercule.js
+++ b/tasks/hercule.js
@@ -18,10 +18,6 @@ module.exports = function (grunt) {
 				grunt.verbose.writeln(msg);
 			},
 			function callback(doc) {
-				// FIXME: unsure how to detect transclusion error since only output
-				// string is passed in.
-				// !err || grunt.fail.fatal(err);
-				
 				grunt.file.write(dest, doc);
 				
 				grunt.log.write(src);

--- a/tasks/hercule.js
+++ b/tasks/hercule.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var hercule = require('hercule/lib/transclude');
+var hercule = require('hercule');
 
 module.exports = function (grunt) {
 	grunt.registerMultiTask('hercule', function () {
@@ -13,16 +13,20 @@ module.exports = function (grunt) {
 		var src = this.filesSrc[0];
 		var dest = this.data.dest;
 		
-		hercule.transclude(src, null, null, null, function (err, doc) {
-			!err || grunt.fail.fatal(err);
-			
-			grunt.file.write(dest, doc);
-			
-			grunt.log.write(src);
-			grunt.log.write(' >> '.green);
-			grunt.log.writeln(dest);
-			
-			done();
-		});
+		hercule.transcludeFile(src,
+			function callback(doc) {
+				// FIXME: unsure how to detect transclusion error since only output
+				// string is passed in.
+				// !err || grunt.fail.fatal(err);
+				
+				grunt.file.write(dest, doc);
+				
+				grunt.log.write(src);
+				grunt.log.write(' >> '.green);
+				grunt.log.writeln(dest);
+				
+				done();
+			}
+		);
 	});
 };

--- a/test/fixtures/api-blueprint/README.md
+++ b/test/fixtures/api-blueprint/README.md
@@ -1,0 +1,64 @@
+# Example: API Blueprint
+
+Borrowing from the Apiary [Gist Fox Tutorial example](http://apiary.io/blueprint), API Blueprint documents can be split into logical files and share common elements.
+
+This example uses a different file for `gists` and `gists/{id}`, and shares a common file `gist.json`.
+
+```
+$ hercule gist-fox.apib -o apiary.apib
+```
+
+Hercule accepts a single source file, in this example `gist-fox.apib`.
+
+```markdown
+FORMAT: 1A
+
+# Gist Fox API
+Gist Fox API is a **pastes service** similar to [GitHub's Gist](http://gist.github.com).
+
+# Group Gist
+
+:[Gist](blueprint/gist.md)
+
+:[Gists](blueprint/gists.md)
+```
+
+Each resource is being stored in its own file, `gist.md` and `gists.md` respectively.
+
+```markdown
+## Gist [/gists/{id}]
+A single Gist object.
+The Gist resource is the central resource in the Gist Fox API.
+It represents one paste - a single text note.
+
++ Parameters
+  + id (string) ... ID of the Gist in the form of a hash.
+
++ Model
+
+    + Body
+
+      ```
+      :[](gist.json)
+      ```
+
+### Retrieve a Single Gist [GET]
+
++ Response 200
+
+  [Gist][]
+```
+
+The common JSON body is stored in `gist.json`.
+
+```json
+{
+  "id": "42",
+  "created_at": "2014-04-14T02:15:15Z",
+  "description": "Description of Gist",
+  "content": "String contents"
+}
+```
+
+See `examples/api-bluprint` for a full example.
+Use `hercule gist-fox.apib | snowcrash` to validate.

--- a/test/fixtures/api-blueprint/blueprint/gist.json
+++ b/test/fixtures/api-blueprint/blueprint/gist.json
@@ -1,0 +1,6 @@
+{
+  "id": "42",
+  "created_at": "2014-04-14T02:15:15Z",
+  "description": "Description of Gist",
+  "content": "String contents"
+}

--- a/test/fixtures/api-blueprint/blueprint/gist.md
+++ b/test/fixtures/api-blueprint/blueprint/gist.md
@@ -1,0 +1,21 @@
+## Gist [/gists/{id}]
+A single Gist object.
+The Gist resource is the central resource in the Gist Fox API.
+It represents one paste - a single text note.
+
++ Parameters
+  + id (string) ... ID of the Gist in the form of a hash.
+
++ Model
+
+    + Body
+
+      ```
+      :[](gist.json)
+      ```
+
+### Retrieve a Single Gist [GET]
+
++ Response 200
+
+  [Gist][]

--- a/test/fixtures/api-blueprint/blueprint/gists.md
+++ b/test/fixtures/api-blueprint/blueprint/gists.md
@@ -1,0 +1,20 @@
+## Gists Collection [/gists{?since}]
+Collection of all Gists.
+
++ Model
+
+    + Body
+
+      ```
+      {
+        "gists": [
+          :[](gist.json)
+        ]
+      }
+      ```
+
+### List All Gists [GET]
+
++ Response 200
+
+  [Gists Collection][]

--- a/test/fixtures/api-blueprint/gist-fox.apib
+++ b/test/fixtures/api-blueprint/gist-fox.apib
@@ -1,0 +1,10 @@
+FORMAT: 1A
+
+# Gist Fox API
+Gist Fox API is a **pastes service** similar to [GitHub's Gist](http://gist.github.com).
+
+# Group Gist
+
+:[Gist](blueprint/gist.md)
+
+:[Gists](blueprint/gists.md)

--- a/test/hercule.spec.js
+++ b/test/hercule.spec.js
@@ -7,7 +7,7 @@ var execOptions = {
 	cwd: path.join(__dirname, '..')
 };
 var fs = require('fs');
-var examplesDir = 'node_modules/hercule/examples/api-blueprint';
+var examplesDir = 'test/fixtures/api-blueprint';
 
 describe('Grunt hercule', function () {
 	this.timeout(5000);


### PR DESCRIPTION
the [hercule](https://github.com/jamesramsay/hercule) dependency (0.2.3) is out of date. (hercule went [1.0 in early july](https://github.com/jamesramsay/hercule/releases/tag/v1.0.0) and is [currently at 1.2.1](https://github.com/jamesramsay/hercule/releases/tag/v1.2.1).)

this PR updates the hercule dependency to 1.2.1. see individual commits for details.
